### PR TITLE
Add Compatibility Tools page

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,48 @@ services:
       - /var/run/wolf:/var/run/wolf
       # Optional, enables Icon/Cover picker for Profiles/Apps.
       - /etc/wolf/covers:/etc/wolf/covers
+      # Optional, enables the Compatibility Tools page (Proton-GE, Luxtorpeda, etc.).
+      # Wolf Den will auto-create the per-OS subdirectories on startup.
+      - /etc/wolf/compatibilitytools.d:/etc/wolf/compatibilitytools.d
+```
+
+### Compatibility Tools
+
+Wolf Den can install and remove Steam-style compatibility tools (Proton-GE,
+Luxtorpeda, Boxtron, Roberta, etc.) into per-OS directories on the host. Upload
+accepts `.tar.gz`, `.tar.xz`, `.tar.bz2`, `.tar`, and `.zip` archives.
+
+The defaults in `appsettings.json` are:
+
+| OS Target | Host Path |
+| --- | --- |
+| Fedora 43 | `/etc/wolf/compatibilitytools.d/fedora43` |
+| Ubuntu    | `/etc/wolf/compatibilitytools.d/ubuntu` |
+
+With `/etc/wolf/compatibilitytools.d` mounted (see the compose example above),
+Wolf Den creates both subdirectories for you on first launch.
+
+> [!IMPORTANT]
+>
+> For Steam to *see* the installed tools, your Steam app's runner container
+> must mount the matching OS directory at Steam's
+> `compatibilitytools.d` location. Wolf Den cannot add this mount on your
+> behalf — it runs in its own container and does not have authority over
+> app-runner configuration.
+>
+> Add a mount to each Steam app via the **Apps → Edit → Advanced Options →
+> Mounts** field. For example, for a Fedora 43-based Steam app:
+>
+> ```
+> /etc/wolf/compatibilitytools.d/fedora43:/home/retro/.steam/root/compatibilitytools.d
+> ```
+>
+> (Adjust the container-side path to match your Steam image's user home.)
+
+To override the default targets, set them in `appsettings.json` or via
+environment variables, e.g.:
+
+```
+WOLF_CompatibilityTools__Targets__0__Name=Fedora 43
+WOLF_CompatibilityTools__Targets__0__Path=/etc/wolf/compatibilitytools.d/fedora43
 ```

--- a/WolfLeash/Components/Classes/CompatibilityToolsOptions.cs
+++ b/WolfLeash/Components/Classes/CompatibilityToolsOptions.cs
@@ -1,0 +1,14 @@
+namespace WolfLeash.Components.Classes;
+
+public class CompatibilityToolsOptions
+{
+    public const string SectionName = "CompatibilityTools";
+
+    public List<CompatibilityToolTarget> Targets { get; set; } = new();
+}
+
+public class CompatibilityToolTarget
+{
+    public string Name { get; set; } = "";
+    public string Path { get; set; } = "";
+}

--- a/WolfLeash/Components/Classes/CompatibilityToolsService.cs
+++ b/WolfLeash/Components/Classes/CompatibilityToolsService.cs
@@ -1,0 +1,222 @@
+using Microsoft.Extensions.Options;
+using SharpCompress.Common;
+using SharpCompress.Readers;
+
+namespace WolfLeash.Components.Classes;
+
+public record CompatibilityTool(string Name, string Path, long SizeBytes);
+
+public class CompatibilityToolsService
+{
+    public static readonly string[] SupportedExtensions =
+        [".tar.gz", ".tgz", ".tar.xz", ".txz", ".tar.bz2", ".tbz2", ".tar", ".zip"];
+
+    private readonly IOptionsMonitor<CompatibilityToolsOptions> _options;
+    private readonly ILogger<CompatibilityToolsService> _logger;
+
+    public CompatibilityToolsService(
+        IOptionsMonitor<CompatibilityToolsOptions> options,
+        ILogger<CompatibilityToolsService> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public IReadOnlyList<CompatibilityToolTarget> Targets => _options.CurrentValue.Targets;
+
+    public bool TargetExists(CompatibilityToolTarget target) => Directory.Exists(target.Path);
+
+    public IReadOnlyList<CompatibilityTool> List(CompatibilityToolTarget target)
+    {
+        if (!Directory.Exists(target.Path)) return Array.Empty<CompatibilityTool>();
+
+        return new DirectoryInfo(target.Path)
+            .EnumerateDirectories()
+            .Where(d => !d.Name.StartsWith(".wolfden-", StringComparison.Ordinal))
+            .Select(d => new CompatibilityTool(d.Name, d.FullName, DirectorySize(d)))
+            .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public void Delete(CompatibilityToolTarget target, string toolName)
+    {
+        var full = ResolveSafe(target, toolName)
+            ?? throw new InvalidOperationException($"Invalid tool name '{toolName}'.");
+
+        if (!Directory.Exists(full))
+            throw new DirectoryNotFoundException(full);
+
+        Directory.Delete(full, recursive: true);
+        _logger.LogInformation("Deleted compatibility tool {Path}", full);
+    }
+
+    public async Task<string> ExtractArchiveAsync(
+        CompatibilityToolTarget target,
+        Stream archiveStream,
+        string originalFileName,
+        CancellationToken ct = default)
+    {
+        if (!IsSupported(originalFileName))
+            throw new NotSupportedException(
+                $"Unsupported archive type for '{originalFileName}'. " +
+                $"Supported: {string.Join(", ", SupportedExtensions)}");
+
+        Directory.CreateDirectory(target.Path);
+
+        var tempExtractRoot = Path.Combine(
+            target.Path,
+            $".wolfden-extract-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempExtractRoot);
+
+        try
+        {
+            await Task.Run(() =>
+            {
+                using var reader = ReaderFactory.Open(archiveStream);
+                var extractOptions = new ExtractionOptions
+                {
+                    ExtractFullPath = true,
+                    Overwrite = true,
+                    PreserveFileTime = true,
+                };
+
+                while (reader.MoveToNextEntry())
+                {
+                    ct.ThrowIfCancellationRequested();
+                    if (reader.Entry.IsDirectory) continue;
+
+                    var entryKey = reader.Entry.Key ?? "";
+                    if (IsUnsafeEntry(entryKey))
+                    {
+                        _logger.LogWarning("Skipping unsafe archive entry {Key}", entryKey);
+                        continue;
+                    }
+
+                    reader.WriteEntryToDirectory(tempExtractRoot, extractOptions);
+                }
+            }, ct);
+
+            var entries = new DirectoryInfo(tempExtractRoot).GetFileSystemInfos();
+            string finalDir;
+
+            if (entries.Length == 1 && entries[0] is DirectoryInfo single)
+            {
+                finalDir = Path.Combine(target.Path, SanitizeName(single.Name));
+                if (Directory.Exists(finalDir))
+                    Directory.Delete(finalDir, recursive: true);
+                Directory.Move(single.FullName, finalDir);
+                Directory.Delete(tempExtractRoot, recursive: true);
+            }
+            else
+            {
+                var stem = SanitizeName(StripArchiveSuffix(originalFileName));
+                if (string.IsNullOrWhiteSpace(stem)) stem = $"tool-{DateTime.UtcNow:yyyyMMddHHmmss}";
+                finalDir = Path.Combine(target.Path, stem);
+                if (Directory.Exists(finalDir))
+                    Directory.Delete(finalDir, recursive: true);
+                Directory.Move(tempExtractRoot, finalDir);
+            }
+
+            _logger.LogInformation("Extracted compatibility tool {Archive} -> {Path}", originalFileName, finalDir);
+            return finalDir;
+        }
+        catch
+        {
+            try { if (Directory.Exists(tempExtractRoot)) Directory.Delete(tempExtractRoot, recursive: true); }
+            catch { /* best effort cleanup */ }
+            throw;
+        }
+    }
+
+    public void ProvisionTargets()
+    {
+        foreach (var target in Targets)
+        {
+            if (string.IsNullOrWhiteSpace(target.Path)) continue;
+            try
+            {
+                // Only auto-create when the grandparent (the host-mounted root, e.g.
+                // /etc/wolf) exists. Otherwise the mount isn't present and creating
+                // the tree would just produce empty container-local dirs that
+                // wouldn't be visible to the Wolf runner containers.
+                var parent = Directory.GetParent(target.Path)?.FullName;
+                var grandparent = parent is null ? null : Directory.GetParent(parent)?.FullName;
+                if (grandparent is null || !Directory.Exists(grandparent))
+                {
+                    _logger.LogInformation(
+                        "Skipping auto-provision of {Path}: mount root not present.",
+                        target.Path);
+                    continue;
+                }
+
+                Directory.CreateDirectory(target.Path);
+                _logger.LogInformation("Ensured compatibility tools directory {Path}", target.Path);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to provision {Path}", target.Path);
+            }
+        }
+    }
+
+    public static bool IsSupported(string fileName)
+    {
+        var lower = fileName.ToLowerInvariant();
+        return SupportedExtensions.Any(ext => lower.EndsWith(ext));
+    }
+
+    private static bool IsUnsafeEntry(string key)
+    {
+        if (string.IsNullOrEmpty(key)) return true;
+        var normalized = key.Replace('\\', '/');
+        if (normalized.StartsWith('/')) return true;
+        foreach (var segment in normalized.Split('/'))
+        {
+            if (segment == "..") return true;
+        }
+        return false;
+    }
+
+    private static string StripArchiveSuffix(string fileName)
+    {
+        var n = fileName;
+        foreach (var suffix in SupportedExtensions)
+        {
+            if (n.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                return n[..^suffix.Length];
+        }
+        return Path.GetFileNameWithoutExtension(n);
+    }
+
+    private static string SanitizeName(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var cleaned = new string(name.Select(c => invalid.Contains(c) ? '_' : c).ToArray()).Trim();
+        if (cleaned is "" or "." or "..") return "tool";
+        return cleaned;
+    }
+
+    private static string? ResolveSafe(CompatibilityToolTarget target, string toolName)
+    {
+        if (string.IsNullOrWhiteSpace(toolName)) return null;
+        if (toolName.Contains('/') || toolName.Contains('\\') || toolName is "." or "..") return null;
+
+        var rootFull = Path.GetFullPath(target.Path);
+        var candidate = Path.GetFullPath(Path.Combine(rootFull, toolName));
+        var sep = Path.DirectorySeparatorChar;
+        if (!candidate.StartsWith(rootFull + sep, StringComparison.Ordinal)) return null;
+        return candidate;
+    }
+
+    private static long DirectorySize(DirectoryInfo dir)
+    {
+        try
+        {
+            return dir.EnumerateFiles("*", SearchOption.AllDirectories).Sum(f => f.Length);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+}

--- a/WolfLeash/Components/Layout/MainLayout.razor
+++ b/WolfLeash/Components/Layout/MainLayout.razor
@@ -85,7 +85,8 @@
 
             //new NavItem { Id = "11", Href = "/info", IconName = IconName.ClipboardData, Text = "Information"  },
             new NavItem { Id = "11", Href = "/covers", IconName = IconName.CardImage, Text = "Covers" },
-            
+            new NavItem { Id = "13", Href = "/compatibilitytools", IconName = IconName.Tools, Text = "Compatibility Tools" },
+
             new NavItem { Id = "12", Href = "/settings", IconName = IconName.Gear, Text = "Settings" }
         };
 

--- a/WolfLeash/Components/Pages/CompatibilityTools/CompatibilityTools.razor
+++ b/WolfLeash/Components/Pages/CompatibilityTools/CompatibilityTools.razor
@@ -1,0 +1,116 @@
+@page "/CompatibilityTools"
+@using WolfLeash.Components.Classes
+@inject CompatibilityToolsService Service
+@inject EventLogger EventLogger
+
+<h3>Compatibility Tools</h3>
+
+@if (Service.Targets.Count == 0)
+{
+    <p>No compatibility tool targets configured. Set <code>CompatibilityTools:Targets</code> in appsettings.json.</p>
+}
+else
+{
+    <Tabs EnableFadeEffect="true">
+        @foreach (var target in Service.Targets)
+        {
+            <Tab Title="@target.Name" IsActive="@(target.Name == _activeTargetName)">
+                <Content>
+                    @{ var exists = Service.TargetExists(target); }
+                    <div class="mb-2">
+                        <small class="text-muted">
+                            Path: <code>@target.Path</code>
+                            @if (!exists)
+                            {
+                                <span class="text-warning"> — directory does not exist; it will be created on first upload.</span>
+                            }
+                        </small>
+                    </div>
+
+                    <div class="mb-3">
+                        <CompatibilityToolUpload Target="@target" OnChanged="@(() => Refresh(target))" />
+                    </div>
+
+                    @{ var tools = _cache.TryGetValue(target.Name, out var c) ? c : Service.List(target); }
+
+                    @if (tools.Count == 0)
+                    {
+                        <p><em>No compatibility tools installed.</em></p>
+                    }
+                    else
+                    {
+                        <table class="table table-sm align-middle">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Size</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var tool in tools)
+                                {
+                                    <tr>
+                                        <td><code>@tool.Name</code></td>
+                                        <td>@FormatSize(tool.SizeBytes)</td>
+                                        <td class="text-end">
+                                            <Button Color="ButtonColor.Danger"
+                                                    @onclick="@(() => Delete(target, tool))">
+                                                Delete
+                                            </Button>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                </Content>
+            </Tab>
+        }
+    </Tabs>
+}
+
+@code {
+    private readonly Dictionary<string, IReadOnlyList<CompatibilityTool>> _cache = new();
+    private string? _activeTargetName;
+
+    protected override void OnInitialized()
+    {
+        _activeTargetName = Service.Targets.FirstOrDefault()?.Name;
+        foreach (var t in Service.Targets)
+            _cache[t.Name] = Service.List(t);
+    }
+
+    private void Refresh(CompatibilityToolTarget target)
+    {
+        _cache[target.Name] = Service.List(target);
+        StateHasChanged();
+    }
+
+    private void Delete(CompatibilityToolTarget target, CompatibilityTool tool)
+    {
+        try
+        {
+            Service.Delete(target, tool.Name);
+            EventLogger.LogEvent(new ToastMessage(ToastType.Info, "",
+                "Removed", $"{DateTime.Now}",
+                $"Deleted {tool.Name} from {target.Name}."));
+            Refresh(target);
+        }
+        catch (Exception ex)
+        {
+            EventLogger.LogEvent(new ToastMessage(ToastType.Danger, "",
+                "Error", $"{DateTime.Now}",
+                $"Failed to delete {tool.Name}: {ex.Message}"));
+        }
+    }
+
+    private static string FormatSize(long bytes)
+    {
+        string[] units = { "B", "KiB", "MiB", "GiB", "TiB" };
+        double value = bytes;
+        int u = 0;
+        while (value >= 1024 && u < units.Length - 1) { value /= 1024; u++; }
+        return $"{value:0.##} {units[u]}";
+    }
+}

--- a/WolfLeash/Components/Pages/CompatibilityTools/SubComponent/CompatibilityToolUpload.razor
+++ b/WolfLeash/Components/Pages/CompatibilityTools/SubComponent/CompatibilityToolUpload.razor
@@ -1,0 +1,69 @@
+@using WolfLeash.Components.Classes
+@inject CompatibilityToolsService Service
+@inject EventLogger EventLogger
+
+<div style="display:flex; flex-direction: row; justify-content: left; align-items: center; gap: 0.5rem;">
+    <a>Upload Archive:</a>
+    <label>
+        <InputFile accept=".tar.gz,.tgz,.tar.xz,.txz,.tar.bz2,.tbz2,.tar,.zip"
+                   OnChange="LoadFiles" multiple/>
+    </label>
+
+    @if (_isLoading)
+    {
+        <div style="width: 300px">
+            <Progress Class="mb-0">
+                <ProgressBar @ref="_progressBar"
+                             Type="ProgressType.StripedAndAnimated"
+                             Color="ProgressColor.Success" />
+            </Progress>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public CompatibilityToolTarget Target { get; set; } = null!;
+    [Parameter] public EventCallback OnChanged { get; set; }
+
+    private bool _isLoading;
+    private ProgressBar? _progressBar;
+
+    private async Task LoadFiles(InputFileChangeEventArgs e)
+    {
+        _isLoading = true;
+        StateHasChanged();
+
+        var files = e.GetMultipleFiles(e.FileCount);
+        foreach (var file in files)
+        {
+            var name = file.Name;
+            if (!CompatibilityToolsService.IsSupported(name))
+            {
+                EventLogger.LogEvent(new ToastMessage(ToastType.Warning, "",
+                    "Unsupported", $"{DateTime.Now}",
+                    $"{name}: supported archives are {string.Join(", ", CompatibilityToolsService.SupportedExtensions)}."));
+                continue;
+            }
+
+            try
+            {
+                await using var stream = file.OpenReadStream(8L * 1024 * 1024 * 1024);
+                var dir = await Service.ExtractArchiveAsync(Target, stream, name);
+                EventLogger.LogEvent(new ToastMessage(ToastType.Info, "",
+                    "Installed", $"{DateTime.Now}",
+                    $"{name} -> {Path.GetFileName(dir)}"));
+                await OnChanged.InvokeAsync();
+                _progressBar?.IncreaseWidth(100.0 / files.Count);
+            }
+            catch (Exception ex)
+            {
+                EventLogger.LogEvent(new ToastMessage(ToastType.Danger, "",
+                    "Error", $"{DateTime.Now}",
+                    $"{name}: {ex.Message}"));
+            }
+        }
+
+        _isLoading = false;
+        StateHasChanged();
+    }
+}

--- a/WolfLeash/Components/_Imports.razor
+++ b/WolfLeash/Components/_Imports.razor
@@ -18,4 +18,5 @@
 @using WolfLeash.Components.Pages.Apps.SubComponent
 @using WolfLeash.Components.Pages.Profiles.SubComponent
 @using WolfLeash.Components.Pages.Covers.SubComponent
+@using WolfLeash.Components.Pages.CompatibilityTools.SubComponent
 @using GamesOnWhales

--- a/WolfLeash/Program.cs
+++ b/WolfLeash/Program.cs
@@ -28,7 +28,13 @@ builder.Services.AddDbContext<WolfLeashDbContext>();
 builder.Services.AddBlazorBootstrap();
 builder.Services.AddScoped<EventLogger>();
 
+builder.Services.Configure<CompatibilityToolsOptions>(
+    builder.Configuration.GetSection(CompatibilityToolsOptions.SectionName));
+builder.Services.AddSingleton<CompatibilityToolsService>();
+
 var app = builder.Build();
+
+app.Services.GetRequiredService<CompatibilityToolsService>().ProvisionTargets();
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())

--- a/WolfLeash/WolfLeash.csproj
+++ b/WolfLeash/WolfLeash.csproj
@@ -22,6 +22,7 @@
         </PackageReference>
 
         <PackageReference Include="System.Data.SQLite" Version="2.0.2" />
+        <PackageReference Include="SharpCompress" Version="0.38.0" />
     </ItemGroup>
         
     <ItemGroup>

--- a/WolfLeash/appsettings.json
+++ b/WolfLeash/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "CompatibilityTools": {
+    "Targets": [
+      { "Name": "Fedora 43", "Path": "/etc/wolf/compatibilitytools.d/fedora43" },
+      { "Name": "Ubuntu",    "Path": "/etc/wolf/compatibilitytools.d/ubuntu" }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- New **Compatibility Tools** page (`/CompatibilityTools`) that lists, uploads, and deletes Steam-style compatibility tools (Proton-GE, Luxtorpeda, Boxtron, Roberta, etc.) in per-OS host directories.
- Extraction via **SharpCompress** so uploads accept `.tar.gz`, `.tar.xz`, `.tar.bz2`, `.tar`, and `.zip`.
- Targets are configurable via `appsettings.json` (`CompatibilityTools:Targets`) or the `WOLF_CompatibilityTools__Targets__*` env-var shape. Ships with defaults for **Fedora 43** → `/etc/wolf/compatibilitytools.d/fedora43` and **Ubuntu** → `/etc/wolf/compatibilitytools.d/ubuntu`.
- Auto-provisioning: on startup, Wolf Den creates each target directory *only if* the host-mount root (grandparent) is present — avoids creating phantom dirs inside the container when the mount is missing.
- README updated with the single new volume (`/etc/wolf/compatibilitytools.d:/etc/wolf/compatibilitytools.d`) and an `!IMPORTANT` note that each Steam app's runner container must mount the matching OS directory at Steam's `compatibilitytools.d` location — that mount is outside Wolf Den's authority and has to be added per-app via Apps → Edit → Mounts.

Safety: the extraction path strips absolute / `..` entries, quarantines to a temp dir before moving into place, and resolves delete requests under the configured root.

## Test plan
- [x] `dotnet build WolfLeash/WolfLeash.csproj` — I don't have .NET locally, so this has not been compiler-verified.
- [x] Launch Wolf Den, confirm the **Compatibility Tools** nav entry appears and the page loads with Fedora 43 / Ubuntu tabs.
- [x] With `/etc/wolf/compatibilitytools.d` mounted, confirm the two OS subdirs are auto-created on startup.
- [x] Upload a `.tar.gz` (Proton-GE) — confirm it extracts, appears in the table with correct size, and lands at `/etc/wolf/compatibilitytools.d/<os>/<tool-name>/` on the host.
- [ ] Upload a `.tar.xz` (Luxtorpeda) — confirm SharpCompress handles it.
- [x] Delete a tool from the UI — confirm the host directory is removed.
- [ ] Wire a Steam app with the matching mount (see README), launch it, and confirm Steam lists the tool under Compatibility.